### PR TITLE
UnfoldableWithIndex

### DIFF
--- a/src/Data/UnfoldableWithIndex.purs
+++ b/src/Data/UnfoldableWithIndex.purs
@@ -1,0 +1,28 @@
+module Data.UnfoldableWithIndex
+  ( class UnfoldableWithIndex, unfoldrWithIndex
+  , none
+  , singleton
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+
+class UnfoldableWithIndex i f | f -> i where
+  unfoldrWithIndex
+    :: forall v b
+     . (b -> Maybe (Tuple (Tuple i v) b))
+    -> b
+    -> f v
+
+none :: forall i f a. UnfoldableWithIndex i f => f a
+none = unfoldrWithIndex (const Nothing) unit
+
+singleton :: forall i v f. UnfoldableWithIndex i f => i -> v -> f v
+singleton i v = unfoldrWithIndex unfoldFn true
+  where
+  unfoldFn true  = Just (Tuple (Tuple i v) false)
+  unfoldFn false = Nothing
+
+-- TODO: fromMaybe


### PR DESCRIPTION
addresses https://github.com/purescript/purescript-unfoldable/issues/14

tested here: https://github.com/matthewleon/purescript-maps/tree/UnfoldableWithIndex

Happy to document this and add some other methods if this is approved. Just don't want to spend the effort if, for whatever reason, people don't like the idea.

This is meant to correspond to all the other `*WithIndex` TCs.